### PR TITLE
Fix starter template list

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ These are not implementations of lit-html itself but rather community extensions
 
 - [open-wc-starter-app](https://github.com/open-wc/open-wc-starter-app) - Starter app based on Open Web Components Recommendations.
 - [generator-lit-element-next](https://github.com/motss/generator-lit-element-next) - Generator for developing your next custom element with latest LitElement in TypeScript.
-- [pwa-starter](https://github.com/pwa-builder/pwa-starter) - LitElement edition of the PWABuilder pwa-starter.
+- [pwa-starter](https://github.com/pwa-builder/pwa-starter) - LitElement edition of the PWABuilder pwa-starter.
 - [@rxdi/starter-client-lit-html](https://github.com/rxdi/starter-client-side-lit-html) - Client side application build with `@rxdi`, lit-html, GraphQL, dependency injection.
 
 ## IDE Plugins


### PR DESCRIPTION
pwa-starter was not getting it's own bullet

before:
<img width="874" alt="Screen Shot 2021-01-19 at 19 48 22" src="https://user-images.githubusercontent.com/3341/105115909-505c9500-5a8f-11eb-9101-9230226b1942.png">
