### PR TITLE
Add Burnish Components — Lit 3 components for structured data

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ At Lit's core is a boilerplate-killing component base class that provides reacti
 - [AgnosticUI](https://github.com/AgnosticUI/agnosticui) - A CLI-based UI component library that copies Lit web components directly into your project. Full React and Vue wrappers for native framework experience.
 - [Apollo Elements](https://github.com/apollo-elements/apollo-elements) - Custom elements meet Apollo GraphQL.
 - [Blackstone UI](https://github.com/kjantzer/bui) - Web components for creating interfaces built with lit-html and LitElement.
-- [Burnish Components](https://github.com/danfking/burnish) - 10 components for rendering structured data as UI — cards, tables, charts, stat bars, forms, pipelines, messages, sections, metrics, actions. Drives the [Burnish Explorer](https://burnish-demo.fly.dev) but works standalone in any app.
+- [Burnish Components](https://github.com/danfking/burnish/tree/main/packages/components) - Web components for rendering MCP tool-call output as UI.
 - [Chartjs Web Components](https://github.com/fsx950223/chartjs-web-components) - Web components for chartjs.
 - [Clever components](https://github.com/CleverCloud/clever-components) - Collection of Web Components made by Clever Cloud.
 - [Curvenote](https://github.com/curvenote/article) - Web components for creating interactive scientific articles.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ At Lit's core is a boilerplate-killing component base class that provides reacti
 - [AgnosticUI](https://github.com/AgnosticUI/agnosticui) - A CLI-based UI component library that copies Lit web components directly into your project. Full React and Vue wrappers for native framework experience.
 - [Apollo Elements](https://github.com/apollo-elements/apollo-elements) - Custom elements meet Apollo GraphQL.
 - [Blackstone UI](https://github.com/kjantzer/bui) - Web components for creating interfaces built with lit-html and LitElement.
+- [Burnish Components](https://github.com/danfking/burnish) - 10 components for rendering structured data as UI — cards, tables, charts, stat bars, forms, pipelines, messages, sections, metrics, actions. Drives the [Burnish Explorer](https://burnish-demo.fly.dev) but works standalone in any app.
 - [Chartjs Web Components](https://github.com/fsx950223/chartjs-web-components) - Web components for chartjs.
 - [Clever components](https://github.com/CleverCloud/clever-components) - Collection of Web Components made by Clever Cloud.
 - [Curvenote](https://github.com/curvenote/article) - Web components for creating interactive scientific articles.


### PR DESCRIPTION
Adds [Burnish Components](https://github.com/danfking/burnish) to **Component Libraries** (placed alphabetically between Blackstone UI and Chartjs Web Components).

A 10-component Lit 3 library published standalone on npm as [`@burnishdev/components`](https://www.npmjs.com/package/@burnishdev/components):

cards · tables · charts · stat bars · sections · metrics · messages · forms · actions · pipelines

The components render structured data from arbitrary JSON — originally built to drive the [Burnish Explorer](https://burnish-demo.fly.dev) (a Swagger-UI-style viewer for MCP servers) but published standalone with only a `lit@^3` peer dependency, so they're fully usable in any Lit app.

**Versioning:** stable at 0.4.x, semver-tracked
**License:** AGPL-3.0
**CDN:** available via esm.sh + jsdelivr
**Types:** ships `.d.ts`

Happy to adjust description length, rename, or move to Standalone Components if you'd prefer that categorization.