### PR TITLE
Add @pionjs/pion

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ These libraries are not related to Lit, but are built using similar concepts. Th
 template literal, and leverage the benefits of the same [IDE Plugins](#ide-plugins) for syntax highlighting.
 
 - [haunted](https://www.npmjs.com/package/haunted) - React's Hooks API but for standard web components and hyperHTML or lit-html.
+- [pion](https://github.com/pionjs/pion) - React Hooks API for web components using lit-html.
 - [htm](https://github.com/developit/htm) - Hyperscript Tagged Markup: JSX alternative using standard tagged templates, with compiler support.
 - [hybrids](https://github.com/hybridsjs/hybrids) - UI library for creating Web Components with simple and functional API.
 - [lit-ntml](https://github.com/motss/lit-ntml) - Lightweight and modern templating for SSR in Node.js, inspired by lit-html.


### PR DESCRIPTION
Adds [pion](https://github.com/pionjs/pion) — React's Hooks API for standard web components with lit-html.

Fork of [haunted](https://github.com/matthewp/haunted), actively maintained with full TypeScript support. Docs: https://pionjs.com · npm: https://npm.im/@pionjs/pion